### PR TITLE
Fix issue with bug navigating away from page.

### DIFF
--- a/src/app/components/hooks/use-model-state.ts
+++ b/src/app/components/hooks/use-model-state.ts
@@ -97,7 +97,7 @@ export const useModelState = <IModelInputState, IModelOutputState>(
         // Don't let client update finished run.
         return oldState;
       }
-      const newState = [...oldState];
+      const newState = [...oldState.map((run) => { return {...run};})];
       newState[activeRunIdx].inputState = {...newState[activeRunIdx].inputState, ...update};
       return newState;
     });
@@ -178,7 +178,7 @@ export const useModelState = <IModelInputState, IModelOutputState>(
 
   const markRunFinished = useCallback(() => {
     setModelRuns(oldState => {
-      const newState = [...oldState];
+      const newState = [...oldState.map((run) => { return {...run};})];
       newState[activeRunIdx].isFinished = true;
       return newState;
     });

--- a/src/app/components/hooks/use-model-state.ts
+++ b/src/app/components/hooks/use-model-state.ts
@@ -97,8 +97,11 @@ export const useModelState = <IModelInputState, IModelOutputState>(
         // Don't let client update finished run.
         return oldState;
       }
-      const newState = [...oldState.map((run) => { return {...run};})];
-      newState[activeRunIdx].inputState = {...newState[activeRunIdx].inputState, ...update};
+      const newState = [...oldState];
+      newState[activeRunIdx] = {
+        ...newState[activeRunIdx],
+        inputState: {...newState[activeRunIdx].inputState, ...update}
+      };
       return newState;
     });
   }, [activeRunIdx]);


### PR DESCRIPTION
@pjanik This PR re-implements an approach you brought up [a question about in an older PR](https://github.com/concord-consortium/plant-growth/pull/4#discussion_r1052237945).

I just realized while double-checking a PT story that when making changes to the inputs in the app, navigating away from the page, and then coming back, the app crashes and the following error comes up in the console:
<img width="670" alt="Screen Shot 2022-12-22 at 12 32 13 PM" src="https://user-images.githubusercontent.com/89816272/209194406-bed662d4-0d9f-4107-9227-d839c56c9115.png">

This approach solves this error, however as you mentioned it might not be the best approach to the problem. I am curious to hear your thoughts.