### PR TITLE
feat: add azimuth buttons, enable camera damping [PT-185469823]

### DIFF
--- a/common/src/components/controls/button.scss
+++ b/common/src/components/controls/button.scss
@@ -20,23 +20,10 @@
     cursor: pointer;
   }
 
-  &.larger {
-    width: 50px;
-    height: 50px;
-    font-size: 18px;
-
-    &.disabled {
-      opacity: .35;
-    }
-  }
-
   .label {
     font-weight: bold;
     margin-bottom: 6px;
     align-self: center;
-    &.larger {
-      font-family: $fontFamilyRoboto;
-    }
   }
 
   .innerButton {
@@ -50,11 +37,6 @@
     background-color: #fff;
     border-radius: 10px;
     border: 3px solid $bluePrimary;
-
-    &.larger {
-      box-shadow: 2px 2px 4px 0 $bluePrimaryTint50;
-      border-width: 4px;
-    }
 
     &.withInnerLabel {
       width: auto;
@@ -95,24 +77,6 @@
       }
     }
 
-    &.larger {
-      &:hover {
-        position: relative;
-        top: -4px;
-        width: 50px;
-        height: 50px;
-        background: $lightBlueTint25;
-      }
-      &:active {
-        position: relative;
-        top: -2.5px;
-        width: 45px;
-        height: 45px;
-        background-color: $bluePrimary;
-        box-shadow: none;
-      }
-    }
-
     &:hover {
       background-color: $lightBlueTint10;
     }
@@ -125,6 +89,4 @@
       }
     }
   }
-
-
 }

--- a/common/src/components/controls/button.tsx
+++ b/common/src/components/controls/button.tsx
@@ -12,27 +12,26 @@ interface IProps {
   horizontal?: boolean;
   height?: number;
   width?: number;
-  largerStyle?: boolean;
   className?: string;
   innerButtonClassName?: string;
 }
 
 export const Button = React.forwardRef<HTMLButtonElement, IProps>((props, ref) => {
-  const { label, innerLabel, icon, disabled, onClick, horizontal, height, width, largerStyle, className, innerButtonClassName } = props;
+  const { label, innerLabel, icon, disabled, onClick, horizontal, height, width, className, innerButtonClassName } = props;
   const divStyle: React.CSSProperties = { height, width };
 
   return (
     <button
       ref={ref}
       tabIndex={0}
-      className={clsx(css.buttonContainer, className, { [css.disabled]: disabled, [css.larger]: largerStyle })}
+      className={clsx(css.buttonContainer, className, { [css.disabled]: disabled })}
       onClick={disabled ? undefined : onClick}
       aria-label={label}
       disabled={disabled}
     >
-      { label && <div className={clsx(css.label, {[css.larger]: largerStyle})}>{ label }</div> }
-      <div style={divStyle} className={clsx(css.innerButton, innerButtonClassName, {[css.larger]: largerStyle, [css.withInnerLabel]: innerLabel, [css.withIcon]: icon, [css.horizontal]: horizontal })}>
-        { icon && <div className={clsx(css.icon, {[css.larger]: largerStyle})}>{ icon }</div> }
+      { label && <div className={clsx(css.label)}>{ label }</div> }
+      <div style={divStyle} className={clsx(css.innerButton, innerButtonClassName, {[css.withInnerLabel]: innerLabel, [css.withIcon]: icon, [css.horizontal]: horizontal })}>
+        { icon && <div className={clsx(css.icon)}>{ icon }</div> }
         { innerLabel && <div className={css.innerLabel}>{ innerLabel }</div> }
       </div>
     </button>

--- a/star-navigation/src/assets/back-icon.svg
+++ b/star-navigation/src/assets/back-icon.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN"
+ "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg"
+ width="512.000000pt" height="512.000000pt" viewBox="0 0 512.000000 512.000000"
+ preserveAspectRatio="xMidYMid meet">
+
+<g transform="translate(0.000000,512.000000) scale(0.100000,-0.100000)"
+fill="#000000" stroke="none">
+<path d="M2395 3360 l-800 -800 800 -800 800 -800 162 162 163 163 -637 637
+-638 638 638 638 637 637 -163 163 -162 162 -800 -800z"/>
+</g>
+</svg>

--- a/star-navigation/src/components/bottom-container.tsx
+++ b/star-navigation/src/components/bottom-container.tsx
@@ -4,11 +4,12 @@ import { Checkbox, Option, ScrollingSelect, useTranslation, LargeToggle } from "
 import { TimeSlider } from "./time-slider";
 import { IModelInputState, Month } from "../types";
 import { daysInMonth, timeToAMPM } from "../utils/sim-utils";
+import { config } from "../config";
+
 import CompassIcon from "../assets/compass_icon.png";
 import CompassSelectedIcon from "../assets/compass_icon_selected.png";
 import AngleIcon from "../assets/angle_icon.png";
 import AngleSelectedIcon from "../assets/angle_icon_selected.png";
-import { config } from "../config";
 
 import css from "./bottom-container.scss";
 

--- a/star-navigation/src/components/simulation/simulation-view.scss
+++ b/star-navigation/src/components/simulation/simulation-view.scss
@@ -11,11 +11,10 @@ $height: 355px;
     height: $height;
     position: relative;
 
-    .sky, .daylight, .landscape, .stars, .pointers, .heading {
+    .sky, .daylight, .landscape, .stars, .pointers, .heading, .buttons {
       width: 100%;
       height: $height;
       position: absolute;
-      // top: 0;
       left: 0;
       background-size: cover;
       pointer-events: none;
@@ -45,6 +44,64 @@ $height: 355px;
       text-align: center;
       top: $height - 25px;
       font-size: 16px;
+    }
+
+    .buttons {
+      top: $height - 70px;
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+
+      .buttonContainer {
+        color: #1cc4ab;
+        text-align: center;
+        font-size: 16px;
+
+        button {
+          box-sizing: border-box;
+          width: 36px;
+          height: 37px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          border: 2px solid $dark-blue;
+          pointer-events: all;
+          margin: 5px 10px;
+          padding: 0;
+          cursor: pointer;
+          background-color: $light-blue;
+
+          svg {
+            height: 100%;
+          }
+
+          svg path {
+            fill: $dark-blue;
+          }
+
+          &:hover {
+            background-color: $blue-hover;
+          }
+
+          &:active {
+            background-color: $blue-active;
+
+            svg path {
+              fill: #fff;
+            }
+          }
+        }
+
+        &:first-child button {
+          border-top-left-radius: 8px;
+          border-bottom-left-radius: 8px;
+        }
+
+        &:last-child button {
+          border-top-right-radius: 8px;
+          border-bottom-right-radius: 8px;
+        }
+      }
     }
   }
 

--- a/star-navigation/src/components/simulation/simulation-view.tsx
+++ b/star-navigation/src/components/simulation/simulation-view.tsx
@@ -7,7 +7,6 @@ import BackIcon from "../../assets/back-icon.svg";
 import { clsx } from "clsx";
 
 import css from "./simulation-view.scss";
-import { Button } from "common";
 
 interface IProps {
   epochTime: number;

--- a/star-navigation/src/components/simulation/simulation-view.tsx
+++ b/star-navigation/src/components/simulation/simulation-view.tsx
@@ -3,9 +3,11 @@ import { IModelInputState } from "../../types";
 import { StarView } from "../star-view/star-view";
 import { daytimeOpacity } from "../../utils/daytime";
 import { getHeadingFromAssumedNorthStar } from "../../utils/sim-utils";
+import BackIcon from "../../assets/back-icon.svg";
 import { clsx } from "clsx";
 
 import css from "./simulation-view.scss";
+import { Button } from "common";
 
 interface IProps {
   epochTime: number;
@@ -22,6 +24,14 @@ export const SimulationView: React.FC<IProps> = ({ inputState, setInputState, ep
 
   const handleRealHeadingFromNorthChange = (realHeadingFromNorth: number) => {
     setInputState({ realHeadingFromNorth });
+  };
+
+  const handleRotateLeft = () => {
+    setInputState({ realHeadingFromNorth: (inputState.realHeadingFromNorth - 5 + 360) % 360 });
+  };
+
+  const handleRotateRight = () => {
+    setInputState({ realHeadingFromNorth: (inputState.realHeadingFromNorth + 5) % 360 });
   };
 
   let headingFromAssumedNorthStar;
@@ -49,6 +59,7 @@ export const SimulationView: React.FC<IProps> = ({ inputState, setInputState, ep
             onStarClick={handleStarClick}
             selectedStarHip={inputState.selectedStarHip}
             compassActive={inputState.compassActive}
+            realHeadingFromNorth={inputState.realHeadingFromNorth}
             onRealHeadingFromNorthChange={handleRealHeadingFromNorthChange}
           />
         </div>
@@ -61,6 +72,16 @@ export const SimulationView: React.FC<IProps> = ({ inputState, setInputState, ep
             Heading: {Math.round(headingFromAssumedNorthStar) % 360}° from North
           </div>
         }
+        <div className={css.buttons}>
+          <div className={css.buttonContainer}>
+            <div>-5°</div>
+            <button onClick={handleRotateLeft}><BackIcon /></button>
+          </div>
+          <div className={css.buttonContainer}>
+            <div>+5°</div>
+            <button onClick={handleRotateRight}><BackIcon style={{transform: "rotate(180deg)"}} /></button>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/star-navigation/src/utils/sim-utils.ts
+++ b/star-navigation/src/utils/sim-utils.ts
@@ -82,6 +82,15 @@ export const toPositiveHeading = (heading: number) => {
   return (360 - heading) % 360;
 };
 
+export const toNegativeHeading = (heading: number) => {
+  // Opposite of toPositiveHeading
+  if (heading > 180) {
+    // [180, 360] range representing N-E-S side
+    return 360 - heading;
+  }
+  return -heading;
+};
+
 export const getStarHeadingFromNorth = (options: { starHip: number, epochTime: number, lat: number, long: number}) => {
   const { starHip, epochTime, lat, long } = options;
   const assumedNorthStarPos = getStarPositionAtTime({


### PR DESCRIPTION
This PR adds azimuth/rotation buttons visible below:
<img width="904" alt="Screenshot 2023-07-17 at 15 28 11" src="https://github.com/concord-consortium/alaskan-simulations/assets/767857/025f2418-434e-4c6c-97c6-3879b0709b45">
I've also enabled camera damping (so had to debounce events too), as it feels nicer when using buttons. The free camera manipulation will be disabled in the final version.
