### PR TITLE
feat: add ?landscapeMarkers URL param and render N/S/W/E markers in the landscape when it's set to true [PT-185647580]

### DIFF
--- a/star-navigation/src/components/simulation/landscape.scss
+++ b/star-navigation/src/components/simulation/landscape.scss
@@ -1,4 +1,4 @@
-@import "common/src/vars.scss";
+@import "../vars.scss";
 
 .landscape {
   width: 100%;
@@ -14,14 +14,36 @@
 
     .landscapeFragment {
       width: 100%;
-      height: 95px;
       display: inline-block;
       position: relative;
 
       img {
         position: absolute;
+        bottom: 0;
         width: 100%;
-        height: 100%;
+        height: 95px;
+      }
+
+      .marker {
+        $color: yellow;
+        $width: 3px;
+        width: $width;
+        margin-left: -0.5 * $width;
+        height: 90px;
+        position: absolute;
+        bottom: 0;
+        left: 50%;
+        background-color: $color;
+        display: flex;
+        justify-content: center;
+        z-index: 1;
+
+        .label {
+          $fontSize: 30px;
+          margin-top: -$fontSize * 1.1;
+          font-size: $fontSize;
+          color: $color;
+        }
       }
     }
   }

--- a/star-navigation/src/components/simulation/landscape.tsx
+++ b/star-navigation/src/components/simulation/landscape.tsx
@@ -1,20 +1,40 @@
 import React, { useEffect, useRef, useState } from "react";
 import { getHorizontalFov } from "../../utils/sim-utils";
 import { config } from "../../config";
+import { Hands } from "./hands";
 import LandscapeImg from "../../assets/CC_Constellation_environment_230711.png";
 import LandscapeImgWithMarkers from "../../assets/CC_Constellation_environment_230711_with_markers.png";
 
 import css from "./landscape.scss";
-import { Hands } from "./hands";
 
 const landscapeFullAngle = 360; // degrees
 
-const LandscapeFragment = () => {
+interface ILandscapeFragmentProps {
+  northMarkerOffset?: number;
+  degreeToPixel: number;
+}
+
+const LandscapeFragment: React.FC<ILandscapeFragmentProps> = ({ northMarkerOffset, degreeToPixel }) => {
   // When freeCamera is used, use image with N/S/W/E markers for debugging/dev purposes.
   const Image = config.freeCamera ? LandscapeImgWithMarkers : LandscapeImg;
+
+  const compassMarkers = config.landscapeMarkers && northMarkerOffset !== undefined ? [
+    { label: "N", offset: northMarkerOffset * degreeToPixel },
+    { label: "E", offset: (northMarkerOffset + 90) * degreeToPixel },
+    { label: "S", offset: (northMarkerOffset + 180) * degreeToPixel },
+    { label: "W", offset: (northMarkerOffset - 90) * degreeToPixel },
+  ] : [];
+
   return (
     <div className={css.landscapeFragment}>
       <img src={Image} />
+      {
+        compassMarkers.map(({ label, offset }) => (
+          <div key={label} className={css.marker} style={{ transform: `translate(${offset}px)` }}>
+            <div className={css.label}>{ label }</div>
+          </div>
+        ))
+      }
     </div>
   );
 };
@@ -51,13 +71,16 @@ export const Landscape: React.FC<IProps> = ({ aspectRatio, realHeadingFromNorth,
     left
   } : undefined;
 
+  const northMarkerOffset =
+    headingFromAssumedNorthStar !== undefined ? (realHeadingFromNorth - headingFromAssumedNorthStar) : undefined;
+
   return (
     <div ref={containerRef} className={css.landscape}>
       <div className={css.imageContainer} style={positionStyles}>
         {/* There are 3 full, repeated landscapes so we don't have to worry about wrapping when user makes a full 360 loop */}
-        <LandscapeFragment />
-        <LandscapeFragment />
-        <LandscapeFragment />
+        <LandscapeFragment northMarkerOffset={northMarkerOffset} degreeToPixel={degreeToPixel} />
+        <LandscapeFragment northMarkerOffset={northMarkerOffset} degreeToPixel={degreeToPixel} />
+        <LandscapeFragment northMarkerOffset={northMarkerOffset} degreeToPixel={degreeToPixel} />
       </div>
       <Hands
         headingFromAssumedNorthStar={headingFromAssumedNorthStar}

--- a/star-navigation/src/components/star-view/compass-markers.tsx
+++ b/star-navigation/src/components/star-view/compass-markers.tsx
@@ -6,6 +6,7 @@ import compassN from "../../assets/compass_icon_selected.png";
 import compassS from "../../assets/compass_s.png";
 import compassW from "../../assets/compass_w.png";
 import compassE from "../../assets/compass_e.png";
+import { config } from "../../config";
 
 const SPRITE_SCALE = 0.0035;
 const SPRITE_WIDTH = SPRITE_SCALE * 82; // px
@@ -53,11 +54,15 @@ const Marker: React.FC<IMarkerProps> = ({ northMarkerTip, direction }) => {
 
   return (
     <object3D rotation={rotation}>
-      <Line
-        points={[topPoint, bottomPoint]}
-        color={COLOR}
-        lineWidth={3}
-      />
+      {
+        // Don't render the line when landscape markers are enabled. This line will be drawn in the landscape component instead.
+        !config.landscapeMarkers &&
+        <Line
+          points={[topPoint, bottomPoint]}
+          color={COLOR}
+          lineWidth={3}
+        />
+      }
       <sprite
         position={topPoint}
         scale={[SPRITE_WIDTH, SPRITE_HEIGHT, 1]}
@@ -81,8 +86,15 @@ interface IProps {
 export const CompassMarkers: React.FC<IProps> = ({ northMarkerTip }) => (
   <>
     <Marker northMarkerTip={northMarkerTip} direction="N" />
-    <Marker northMarkerTip={northMarkerTip} direction="E" />
-    <Marker northMarkerTip={northMarkerTip} direction="S" />
-    <Marker northMarkerTip={northMarkerTip} direction="W" />
+    {
+      // E/S/W markers are not rendered when landscape markers are enabled.
+      // These markers will be drawn in the landscape component instead.
+      !config.landscapeMarkers &&
+      <>
+        <Marker northMarkerTip={northMarkerTip} direction="E" />
+        <Marker northMarkerTip={northMarkerTip} direction="S" />
+        <Marker northMarkerTip={northMarkerTip} direction="W" />
+      </>
+    }
   </>
 );

--- a/star-navigation/src/config.ts
+++ b/star-navigation/src/config.ts
@@ -19,15 +19,17 @@ export interface IConfig {
   // Minimum absolute star magnitude needed for star to be shown in both views
   minAbsStarMagnitude: number;
 
+  //--- New Alaskan Simulation Star Navigation params: ---
   constellations: string;
   constellationsOpacity: number;
-
   // Whether to show the route map on the right side of the star map.
   routeMap: boolean;
   // When set to false, it disabled any camera movement besides the rotation buttons.
   freeCamera: boolean;
   // When set to true, hands angle display shows range from 0 to 360 degrees. Otherwise, it shows 0 to 180.
   hands360: boolean;
+  // When set to true, N/W/S/E markers are shown in the landscape view instead of the 3D view.
+  landscapeMarkers: boolean;
 }
 
 const defaultConfig: IConfig = {
@@ -43,6 +45,7 @@ const defaultConfig: IConfig = {
   routeMap: false,
   freeCamera: false,
   hands360: false,
+  landscapeMarkers: true,
 };
 
 // Config is cached when module is loaded. That's fine, as URL parameters will not change in normal situation.


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185647580

This PR adds a new param that moves the rendering of N/S/W/E markers from 3D space (correct) to the landscape layer (not really correct, but preferred by PIs as it's probably less confusing to students).