### PR TITLE
feat: add LARA Interactive API state saving and report support [PT-185511665]

### DIFF
--- a/plant-growth/package.json
+++ b/plant-growth/package.json
@@ -120,7 +120,7 @@
     "zip-webpack-plugin": "^4.0.1"
   },
   "dependencies": {
-    "@concord-consortium/lara-interactive-api": "^1.7.2",
+    "@concord-consortium/lara-interactive-api": "^1.9.4",
     "@dnd-kit/core": "^5.0.3",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",

--- a/star-navigation/package.json
+++ b/star-navigation/package.json
@@ -114,6 +114,7 @@
     "zip-webpack-plugin": "^4.0.1"
   },
   "dependencies": {
+    "@concord-consortium/lara-interactive-api": "^1.9.4",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/material": "^5.14.0",

--- a/star-navigation/src/components/interactive.tsx
+++ b/star-navigation/src/components/interactive.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect } from "react";
+import { useInitMessage, setSupportedFeatures } from "@concord-consortium/lara-interactive-api";
+import { App } from "./app";
+import { IInteractiveState } from "../types";
+
+export const Interactive: React.FC = () => {
+  const initMessage = useInitMessage<IInteractiveState>();
+
+  useEffect(() => {
+    if (initMessage) {
+      setSupportedFeatures({
+        authoredState: false,
+        interactiveState: true
+      });
+    }
+  }, [initMessage]);
+
+  switch (initMessage?.mode || "runtime") {
+    case "runtime":
+      return <App />;
+    case "authoring":
+      return <>This interactive does not provide authoring interface</>;
+    case "report":
+      return <App readOnly={true} />;
+    default:
+      return <>Error: unknown or unsupported mode: {initMessage?.mode}</>;
+  }
+};

--- a/star-navigation/src/index.tsx
+++ b/star-navigation/src/index.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
-import { App } from "./components/app";
+import { Interactive } from "./components/interactive";
 import "./index.scss";
 
 const container = document.getElementById("app");
 
 if (container) {
   const root = createRoot(container);
-  root.render(<App />);
+  root.render(<Interactive />);
 }

--- a/star-navigation/src/types.ts
+++ b/star-navigation/src/types.ts
@@ -1,3 +1,5 @@
+import { IRuntimeInteractiveMetadata } from "@concord-consortium/lara-interactive-api";
+
 export enum Constellation {
   // Translation keys should match the values.
   Virgo = "CONSTELLATION.VIRGO",
@@ -64,4 +66,9 @@ export interface IModelInputState {
 }
 
 export interface IModelOutputState {
+}
+
+export interface IInteractiveState extends IRuntimeInteractiveMetadata {
+  inputState: IModelInputState,
+  readAloudMode: boolean
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1117,10 +1117,10 @@
   resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@concord-consortium/lara-interactive-api@^1.7.2":
-  version "1.8.0"
-  resolved "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.8.0.tgz"
-  integrity sha512-mfw/7o9HykS1y/Xw6FYrwezDhtXwPgoTYbxnObFZNyd0kfOAFlJX8bLrO8xZclvvHNADlCTERKk1YV5F7OhTMw==
+"@concord-consortium/lara-interactive-api@^1.9.4":
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.9.4.tgz#599984e00ae176711a850d199658849e9d8ed0ca"
+  integrity sha512-KzwrCFs56t+TRoC7OVDXGRXRuyl+QS1+SE0LpXoihfCPKnJrvAUjmzEQt+TXdTRXjZLwa1stIbXlMzzS9MRmmw==
   dependencies:
     iframe-phone "^1.3.1"
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185511665

This PR adds support for LARA Interactive API state saving. I think it's the slimmest variant possible where `useInteractiveState` hooks provide most of the necessary logic and the `Interactive` component looks at the init message to decide whether we need to render runtime, report or authoring.

I've stopped using FOSS-based `useModelState` with all the runs logic, as this sim has single run and no runs-based table or graph.

I should probably slightly refactor Plant Growth too, but not sure if there's time for that, so I'll leave it for later.
