### PR TITLE
Add angle annotation to angle markers, keep just one 3D interaction active at the same time

### DIFF
--- a/star-navigation/src/components/bottom-container.tsx
+++ b/star-navigation/src/components/bottom-container.tsx
@@ -45,11 +45,22 @@ export const BottomContainer: React.FC<IProps> = ({ inputState, disableInputs, s
   const handleWesternConstellationsChange = (event: React.ChangeEvent<HTMLInputElement>) =>
     setInputState({ showWesternConstellations: event.target.checked });
 
-  const handleCompassModeChange = (event: React.ChangeEvent<HTMLInputElement>) =>
-    setInputState({ compassInteractionActive: event.target.checked });
+  const handleCompassModeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const compassInteractionActive = event.target.checked;
+    setInputState({ compassInteractionActive });
+    if (compassInteractionActive) {
+      setInputState({ angleMarkerInteractionActive: false });
+    }
+  };
 
-  const handleAngleMarkerModeChange = (event: React.ChangeEvent<HTMLInputElement>) =>
-    setInputState({ angleMarkerInteractionActive: event.target.checked });
+
+  const handleAngleMarkerModeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const angleMarkerInteractionActive = event.target.checked;
+    setInputState({ angleMarkerInteractionActive });
+    if (angleMarkerInteractionActive) {
+      setInputState({ compassInteractionActive: false });
+    }
+  };
 
   const monthKeySuffix = config.routeMap ? "_SHORT" : "";
 

--- a/star-navigation/src/components/simulation/simulation-view.scss
+++ b/star-navigation/src/components/simulation/simulation-view.scss
@@ -40,6 +40,7 @@ $height: 355px;
       pointer-events: none;
       background-position: center;
       background-size: contain;
+      z-index: 100;
     }
 
     .heading {

--- a/star-navigation/src/components/star-view/angle-marker.tsx
+++ b/star-navigation/src/components/star-view/angle-marker.tsx
@@ -1,7 +1,11 @@
 import React from "react";
+import * as THREE from "three";
 import { IAngleMarker } from "../../types";
-import { Line } from "@react-three/drei";
+import { Html, Line } from "@react-three/drei";
 import { getCelestialSphereRotation } from "../../utils/sim-utils";
+
+const ANGLE_ANNOTATION_OFFSET = 50;
+const MIN_ANGLE = 2;
 
 interface IProps {
   angleMarker: IAngleMarker | null;
@@ -19,23 +23,57 @@ export const AngleMarker: React.FC<IProps> = (props) => {
   const originalRotation = getCelestialSphereRotation({ epochTime: angleMarker.createdAtEpoch, lat, long });
   const currentRotation = getCelestialSphereRotation({ epochTime: currentEpochTime, lat, long });
 
+  // Angle between lines is essentially equal to rotation of the celestial sphere between two points in time,
+  // and that's obviously easier to calculate.
+  let rotationDiff = THREE.MathUtils.radToDeg(originalRotation[1] - currentRotation[1]) % 360;
+  if (rotationDiff < 0) {
+    rotationDiff += 360;
+  }
+
+  const showAngleAnnotation = rotationDiff > MIN_ANGLE && rotationDiff < (360 - MIN_ANGLE);
+
+  let label1Pos, label2Pos, htmlCommonProps;
+  if (showAngleAnnotation) {
+    const start = new THREE.Vector3(...angleMarker.startPoint);
+    const end = new THREE.Vector3(...angleMarker.endPoint);
+    const direction = end.clone().sub(start).normalize();
+    label1Pos = start.clone().sub(direction.clone().multiplyScalar(ANGLE_ANNOTATION_OFFSET));
+    label2Pos = end.clone().add(direction.clone().multiplyScalar(ANGLE_ANNOTATION_OFFSET));
+
+    htmlCommonProps = {
+      center: true,
+      zIndexRange: [1, 0], // default z-index range uses some enormous values and brakes daylight layer
+      style: {
+        color: "white",
+        fontSize: 20
+      }
+    };
+  }
+
   return (
     <>
       <object3D rotation={originalRotation}>
         <Line
           points={[angleMarker.startPoint, angleMarker.endPoint]}
-          color={"white"}
+          color="white"
           lineWidth={3}
         />
       </object3D>
       <object3D rotation={currentRotation}>
         <Line
           points={[angleMarker.startPoint, angleMarker.endPoint]}
-          color={"white"}
+          color="white"
           lineWidth={3}
           opacity={0.65}
           transparent={true}
         />
+        {
+          showAngleAnnotation &&
+          <>
+            <Html position={label1Pos} {...htmlCommonProps}>{ rotationDiff.toFixed(0) }°</Html>
+            <Html position={label2Pos} {...htmlCommonProps}>{ rotationDiff.toFixed(0) }°</Html>
+          </>
+        }
       </object3D>
     </>
   );


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185463396

This PR adds missing angle annotation to the angle marker.
Also, it fixes a bug where two 3D interactions could be active at the same time.