### PR TITLE
feat: snap to stars while drawing angle marker [PT-185463396]

### DIFF
--- a/star-navigation/src/components/app.tsx
+++ b/star-navigation/src/components/app.tsx
@@ -30,7 +30,7 @@ const defaultInteractiveState: IInteractiveState = {
     showWesternConstellations: true,
     showYupikConstellations: true,
     realHeadingFromNorth: 90,
-    selectedStarHip: null,
+    assumedNorthStarHip: null,
     angleMarker: null,
     compassInteractionActive: false,
     angleMarkerInteractionActive: false

--- a/star-navigation/src/components/star-view/celestial-sphere.tsx
+++ b/star-navigation/src/components/star-view/celestial-sphere.tsx
@@ -2,19 +2,16 @@ import React from "react";
 import { Stars } from "./stars";
 import { WesternConstellations } from "./western-constellations";
 import { YupikConstellations } from "./yupik-constallations";
-import { InteractiveStars } from "./interactive-stars";
 
 interface IProps {
   rotation: [number, number, number];
   radius: number;
   showWesternConstellations: boolean;
   showYupikConstellations: boolean;
-  onStarClick: (starHip: number) => void;
-  compassInteractionActive: boolean;
 }
 
 export const CelestialSphere: React.FC<IProps> = (props) => {
-  const { rotation, radius, showWesternConstellations, showYupikConstellations, onStarClick, compassInteractionActive } = props;
+  const { rotation, radius, showWesternConstellations, showYupikConstellations } = props;
 
   return (
     <object3D rotation={rotation}>
@@ -26,10 +23,6 @@ export const CelestialSphere: React.FC<IProps> = (props) => {
       {
         showYupikConstellations &&
         <YupikConstellations radius={radius * 1.1} />
-      }
-      {
-        compassInteractionActive &&
-        <InteractiveStars radius={radius * 1.2} onStarClick={onStarClick} />
       }
     </object3D>
   );

--- a/star-navigation/src/components/star-view/interactive-celestial-sphere.tsx
+++ b/star-navigation/src/components/star-view/interactive-celestial-sphere.tsx
@@ -1,37 +1,40 @@
-import React, { useState } from "react";
+import React from "react";
 import { ThreeEvent } from "@react-three/fiber";
 import * as THREE from "three";
 
 interface IProps {
   radius: number;
-  onStartPointChange: (startPoint: THREE.Vector3) => void;
-  onEndPointChange: (endPoint: THREE.Vector3) => void;
+  onPointerDown?: (point: THREE.Vector3) => void;
+  onPointerMove?: (point: THREE.Vector3) => void;
+  onPointerUp?: (point: THREE.Vector3) => void;
+  onPointerCancel?: (point: THREE.Vector3) => void;
 }
 
 export const InteractiveCelestialSphere: React.FC<IProps> = (props) => {
-  const { radius, onStartPointChange, onEndPointChange } = props;
-
-  const [pointerDown, setPointerDown] = useState(false);
+  const { radius, onPointerDown, onPointerMove, onPointerUp, onPointerCancel } = props;
 
   const handlePointerDown = (event: ThreeEvent<PointerEvent>) => {
-    setPointerDown(true);
-    onStartPointChange(event.point);
-  };
-
-  const handlePointerUp = () => {
-    setPointerDown(false);
+    onPointerDown?.(event.point);
   };
 
   const handlePointerMove = (event: ThreeEvent<PointerEvent>) => {
-    onEndPointChange(event.point);
+    onPointerMove?.(event.point);
+  };
+
+  const handlePointerUp = (event: ThreeEvent<PointerEvent>) => {
+    onPointerUp?.(event.point);
+  };
+
+  const handlePointerCancel = (event: ThreeEvent<PointerEvent>) => {
+    onPointerCancel?.(event.point);
   };
 
   return (
     <mesh
       onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
-      onPointerCancel={handlePointerUp}
-      onPointerMove={pointerDown ? handlePointerMove : undefined}
+      onPointerCancel={handlePointerCancel}
     >
       <sphereGeometry args={[radius, 32, 32]} />
       <meshBasicMaterial color="white" side={THREE.DoubleSide} opacity={0} transparent={true} />

--- a/star-navigation/src/components/star-view/interactive-stars.tsx
+++ b/star-navigation/src/components/star-view/interactive-stars.tsx
@@ -11,17 +11,24 @@ const SPRITE_SCALE = 0.1;
 
 interface IProps {
   radius: number;
-  onStarClick: (starHip: number) => void;
+  rotation: [number, number, number];
+  onStarClick?: (point: THREE.Vector3, starHip: number) => void;
+  onStarPointerDown?: (point: THREE.Vector3, starHip: number) => void;
+  onStarPointerUp?: (point: THREE.Vector3, starHip: number) => void;
 }
 
-export const InteractiveStars: React.FC<IProps> = ({ radius, onStarClick }) => {
+export const InteractiveStars: React.FC<IProps> = ({ radius, rotation, onStarClick, onStarPointerDown, onStarPointerUp }) => {
   const circleTexture = useLoader(THREE.TextureLoader, circleImg) as THREE.Texture;
   const [hovered, setHovered] = useState(-1);
 
   const stars = getFilteredStars();
 
+  const rotationEuler = new THREE.Euler(...rotation);
+  const getStarPosition = (starPosWithoutRotation: THREE.Vector3) =>
+    starPosWithoutRotation.clone().applyEuler(rotationEuler);
+
   return (
-    <object3D>
+    <object3D rotation={rotation}>
       {
         !SPRITE_RENDERING &&
         stars.map((star, index) => {
@@ -54,7 +61,9 @@ export const InteractiveStars: React.FC<IProps> = ({ radius, onStarClick }) => {
               position={[pos.x, pos.y, pos.z]}
               onPointerOver={() => setHovered(star.Hip)}
               onPointerOut={() => hovered === star.Hip && setHovered(-1)}
-              onClick={() => onStarClick(star.Hip)}
+              onClick={(event) => onStarClick?.(getStarPosition(event.object.position), star.Hip)}
+              onPointerDown={(event) => onStarPointerDown?.(getStarPosition(event.object.position), star.Hip)}
+              onPointerUp={(event) => onStarPointerUp?.(getStarPosition(event.object.position), star.Hip)}
               scale={[SPRITE_SCALE, SPRITE_SCALE, SPRITE_SCALE]}
             >
               <spriteMaterial

--- a/star-navigation/src/types.ts
+++ b/star-navigation/src/types.ts
@@ -67,7 +67,7 @@ export interface IModelInputState {
   showWesternConstellations: boolean;
   showYupikConstellations: boolean;
   realHeadingFromNorth: number; // degree
-  selectedStarHip: number | null;
+  assumedNorthStarHip: number | null;
   angleMarker: IAngleMarker | null;
   // interactions
   compassInteractionActive: boolean;

--- a/star-navigation/src/utils/sim-utils.ts
+++ b/star-navigation/src/utils/sim-utils.ts
@@ -68,8 +68,7 @@ export const invertCelestialSphereRotation = (options: { point: THREE.Vector3, e
   const { point, epochTime, lat, long } = options;
   const eulerRotation = new THREE.Euler(...getCelestialSphereRotation({ epochTime, lat, long }));
   const quaternionInverted = (new THREE.Quaternion().setFromEuler(eulerRotation)).invert();
-  point.applyQuaternion(quaternionInverted);
-  return point;
+  return point.clone().applyQuaternion(quaternionInverted);
 };
 
 export const getStarPositionAtTime = (options: { starHip: number, celestialSphereRadius: number, epochTime: number, lat: number, long: number}) => {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185463396

One more update to the angle marker line drawing. Nathan suggested I should stick to the originally required method of drawing which forces the user to connect two stars. So, this PR implements this feature. It's possible to draw a line only between two stars and the line will snap to them on both ends. I had to move some helpers around.