### PR TITLE
feat: implement right panel and snapshot functionalities [PT-185463715]

### DIFF
--- a/star-navigation/src/components/app.tsx
+++ b/star-navigation/src/components/app.tsx
@@ -13,10 +13,6 @@ import HeaderTitle from "../assets/title.png";
 
 import css from "./app.scss";
 
-// Observer location is at Hooper Bay, Alaska.
-const OBSERVER_LAT = 61.523997904;
-const OBSERVER_LON = -166.090999636;
-
 interface IProps {
   readOnly?: boolean;
 }
@@ -33,7 +29,12 @@ const defaultInteractiveState: IInteractiveState = {
     assumedNorthStarHip: null,
     angleMarker: null,
     compassInteractionActive: false,
-    angleMarkerInteractionActive: false
+    angleMarkerInteractionActive: false,
+    pointADepartureSnapshot: null,
+    pointBArrivalSnapshot: null,
+    pointBDepartureSnapshot: null,
+    pointCArrivalSnapshot: null,
+    journeyLeg: "AtoB"
   },
   readAloudMode: false
 };
@@ -67,7 +68,7 @@ export const App: React.FC<IProps> = ({ readOnly }) => {
     }));
   };
 
-  const date = new Date(getDateTimeString(inputState.month, inputState.day, inputState.timeOfDay));
+  const date = new Date(getDateTimeString(inputState));
   const epochTime = date.getTime();
 
   return (
@@ -83,8 +84,6 @@ export const App: React.FC<IProps> = ({ readOnly }) => {
               <SimulationView
                 inputState={inputState}
                 epochTime={epochTime}
-                observerLat={OBSERVER_LAT}
-                observerLon={OBSERVER_LON}
                 setInputState={setInputState}
               />
             </div>

--- a/star-navigation/src/components/bottom-container/bottom-container.tsx
+++ b/star-navigation/src/components/bottom-container/bottom-container.tsx
@@ -112,18 +112,11 @@ export const BottomContainer: React.FC<IProps> = ({ inputState, disableInputs, s
                 disabled={disableInputs}
                 valueMinWidth={config.routeMap ? 53 : 92}
               >
-                <Option value="1">{t(Month.January + monthKeySuffix)}</Option>
-                <Option value="2">{t(Month.February + monthKeySuffix)}</Option>
-                <Option value="3">{t(Month.March + monthKeySuffix)}</Option>
-                <Option value="4">{t(Month.April + monthKeySuffix)}</Option>
-                <Option value="5">{t(Month.May + monthKeySuffix)}</Option>
-                <Option value="6">{t(Month.June + monthKeySuffix)}</Option>
-                <Option value="7">{t(Month.July + monthKeySuffix)}</Option>
-                <Option value="8">{t(Month.August + monthKeySuffix)}</Option>
-                <Option value="9">{t(Month.September + monthKeySuffix)}</Option>
-                <Option value="10">{t(Month.October + monthKeySuffix)}</Option>
-                <Option value="11">{t(Month.November + monthKeySuffix)}</Option>
-                <Option value="12">{t(Month.December + monthKeySuffix)}</Option>
+                {
+                  Object.keys(Month).map((montNumber: string) => (
+                    <Option key={montNumber} value={montNumber}>{t(Month[Number(montNumber)] + monthKeySuffix)}</Option>
+                  ))
+                }
               </ScrollingSelect>
             </div>
           </div>

--- a/star-navigation/src/components/bottom-container/bottom-container.tsx
+++ b/star-navigation/src/components/bottom-container/bottom-container.tsx
@@ -113,8 +113,8 @@ export const BottomContainer: React.FC<IProps> = ({ inputState, disableInputs, s
                 valueMinWidth={config.routeMap ? 53 : 92}
               >
                 {
-                  Object.keys(Month).map((montNumber: string) => (
-                    <Option key={montNumber} value={montNumber}>{t(Month[Number(montNumber)] + monthKeySuffix)}</Option>
+                  Object.keys(Month).map((monthNumber: string) => (
+                    <Option key={monthNumber} value={monthNumber}>{t(Month[Number(monthNumber)] + monthKeySuffix)}</Option>
                   ))
                 }
               </ScrollingSelect>

--- a/star-navigation/src/components/button.scss
+++ b/star-navigation/src/components/button.scss
@@ -14,11 +14,23 @@
   border-radius: 8px;
   font-size: 16px;
 
+  &.disabled {
+    color: $font-color;
+    pointer-events: none;
+    opacity: 0.5;
+  }
+
   &:hover {
     background-color: $blue-hover;
   }
 
   &:active {
     background-color: $blue-active;
+  }
+
+  &.selected {
+    background-color: $dark-blue;
+    color: $white;
+    pointer-events: none;
   }
 }

--- a/star-navigation/src/components/button.tsx
+++ b/star-navigation/src/components/button.tsx
@@ -7,12 +7,15 @@ interface IProps {
   children: React.ReactNode;
   className?: string;
   onClick?: () => void;
+  disabled?: boolean;
+  selected?: boolean;
 }
 
-export const Button: React.FC<IProps> = ({ children, className, onClick }) => {
+export const Button: React.FC<IProps> = ({ children, className, onClick, selected, disabled }) => {
   return (
     <button
-      className={clsx(css.button, className)}
+      className={clsx(css.button, className, { [css.selected]: selected, [css.disabled]: disabled })}
+      disabled={disabled || selected}
       onClick={onClick}
     >
       { children }

--- a/star-navigation/src/components/right-container/right-container.tsx
+++ b/star-navigation/src/components/right-container/right-container.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import clsx from "clsx";
 import { useTranslation } from "common";
-import { IModelInputState } from "../../types";
+import { IModelInputState, ISnapshot, SNAPSHOT_REQUESTED } from "../../types";
 import { RouteMap } from "./route-map";
 import { Button } from "../button";
 import { Snapshot } from "./snapshot";
@@ -17,26 +17,67 @@ interface IProps {
 export const RightContainer: React.FC<IProps> = ({ inputState, disableInputs, setInputState }) => {
   const { t, tStringOnly } = useTranslation();
 
+  const { journeyLeg } = inputState;
+  const AtoB = journeyLeg === "AtoB";
+  const departurePoint = AtoB ? "A" : "B";
+  const arrivalPoint = AtoB ? "B" : "C";
+  const departureSnapshot = inputState[`point${departurePoint}DepartureSnapshot`]; // this is type safe
+  const arrivalSnapshot = inputState[`point${arrivalPoint}ArrivalSnapshot`]; // this is type safe
+  const snapshotDisabled = !inputState.assumedNorthStarHip;
+  const takeYourTripDisabled = !inputState.pointADepartureSnapshot || !inputState.pointBArrivalSnapshot || !inputState.pointBDepartureSnapshot || !inputState.pointCArrivalSnapshot;
+
+  const handleJourneyChangeAtoB = () => setInputState({ journeyLeg: "AtoB" });
+
+  const handleJourneyChangeBtoC = () => setInputState({ journeyLeg: "BtoC" });
+
+  const getSnapshotData = (): ISnapshot | null => {
+    if (!inputState.assumedNorthStarHip) {
+      return null;
+    }
+    return {
+      month: inputState.month,
+      day: inputState.day,
+      timeOfDay: inputState.timeOfDay,
+      assumedNorthStarHip: inputState.assumedNorthStarHip,
+      realHeadingFromNorth: inputState.realHeadingFromNorth,
+      // This is a special value that will trigger snapshot generation in the star-view component.
+      // When the snapshot is ready, a state here will be updated.
+      starViewImageSnapshot: SNAPSHOT_REQUESTED
+    };
+  };
+
+  const handleTakeDepartureSnapshot = () =>
+    setInputState(AtoB ? { pointADepartureSnapshot: getSnapshotData() } : { pointBDepartureSnapshot: getSnapshotData() });
+
+  const handleTakeArrivalSnapshot = () =>
+    setInputState(AtoB ? { pointBArrivalSnapshot: getSnapshotData() } : { pointCArrivalSnapshot: getSnapshotData() });
+
   return (
     <div className={css.rightContainer}>
       <div className={css.label}>{t("PLAN_YOUR_ROUTE")}</div>
       <RouteMap />
       <div className={css.label}>{t("CHART_HEADINGS_TIMES")}</div>
-      <div className={clsx(css.label, css.light)}>{t("DEPARTURE_FROM_POINT_A")}</div>
+      <div className={clsx(css.label, css.light)}>{t(`DEPARTURE_FROM_POINT_${departurePoint}`)}</div>
       <div className={css.container}>
         <Snapshot
-          buttonLabel={tStringOnly("RECORD_STAR_CHART_FOR_POINT_A_DEPARTURE")}
+          buttonLabel={tStringOnly(`RECORD_STAR_CHART_FOR_POINT_${departurePoint}_DEPARTURE`)}
+          snapshot={departureSnapshot}
+          onTakeSnapshot={handleTakeDepartureSnapshot}
+          disabled={snapshotDisabled}
         />
       </div>
-      <div className={clsx(css.label, css.light)}>{t("ARRIVAL_AT_POINT_B")}</div>
+      <div className={clsx(css.label, css.light)}>{t(`ARRIVAL_AT_POINT_${arrivalPoint}`)}</div>
       <div className={css.container}>
         <Snapshot
-          buttonLabel={tStringOnly("RECORD_STAR_CHART_FOR_POINT_B_ARRIVAL")}
+          buttonLabel={tStringOnly(`RECORD_STAR_CHART_FOR_POINT_${arrivalPoint}_ARRIVAL`)}
+          snapshot={arrivalSnapshot}
+          onTakeSnapshot={handleTakeArrivalSnapshot}
+          disabled={snapshotDisabled}
         />
         <div className={css.buttonsRow}>
-          <Button>{tStringOnly("A_TO_B")}</Button>
-          <Button>{tStringOnly("B_TO_C")}</Button>
-          <Button className={css.takeYourTripBtn}>{tStringOnly("TAKE_YOUR_TRIP")}</Button>
+          <Button selected={AtoB} onClick={handleJourneyChangeAtoB}>{ tStringOnly("A_TO_B") }</Button>
+          <Button selected={!AtoB} onClick={handleJourneyChangeBtoC}>{ tStringOnly("B_TO_C") }</Button>
+          <Button className={css.takeYourTripBtn} disabled={takeYourTripDisabled}>{tStringOnly("TAKE_YOUR_TRIP")}</Button>
         </div>
       </div>
     </div>

--- a/star-navigation/src/components/right-container/snapshot.scss
+++ b/star-navigation/src/components/right-container/snapshot.scss
@@ -1,9 +1,27 @@
 @import "../vars.scss";
 
 .snapshot {
-  .snapshotButton {
+  .snapshotButton, .snapshotData {
     width: 180px;
     height: 90px;
     border-radius: 15px;
+    box-sizing: border-box;
+  }
+
+  .snapshotData {
+    background-color: $dark-blue;
+    background-size: cover;
+    padding: 5px;
+    color: #ffea00;
+    text-shadow: 2px 2px 3px #000;
+    font-size: 14px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .textUppercase {
+    text-transform: uppercase;
   }
 }

--- a/star-navigation/src/components/right-container/snapshot.tsx
+++ b/star-navigation/src/components/right-container/snapshot.tsx
@@ -1,16 +1,57 @@
 import React from "react";
+import { useTranslation } from "common";
+import { config } from "../../config";
 import { Button } from "../button";
+import { ISnapshot, Month, SNAPSHOT_REQUESTED } from "../../types";
+import { getDateTimeString, getHeadingFromAssumedNorthStar, timeToAMPM } from "../../utils/sim-utils";
 
 import css from "./snapshot.scss";
 
 interface IProps {
   buttonLabel: string;
+  snapshot: ISnapshot | null;
+  onTakeSnapshot: () => void;
+  disabled: boolean;
 }
 
-export const Snapshot: React.FC<IProps> = ({ buttonLabel }) => {
+const SnapshotData: React.FC<{ snapshot: ISnapshot }> = ({ snapshot }) => {
+  const { t } = useTranslation();
+  const { month, day, timeOfDay, starViewImageSnapshot, assumedNorthStarHip, realHeadingFromNorth } = snapshot;
+
+  const date = new Date(getDateTimeString(snapshot));
+  const epochTime = date.getTime();
+  const headingFromAssumedNorthStar = getHeadingFromAssumedNorthStar({
+    assumedNorthStarHip,
+    realHeadingFromNorth,
+    epochTime,
+    lat: config.observerLat,
+    long: config.observerLong
+  });
+
+  return (
+    <div className={css.snapshotData} style={starViewImageSnapshot !== SNAPSHOT_REQUESTED ? { backgroundImage: `url(${starViewImageSnapshot})` } : undefined}>
+      <div className={css.textUppercase}>
+        { t(Month[month] + "_SHORT") } { day } { timeToAMPM(timeOfDay) }
+      </div>
+      <div className={css.text}>
+        {/* % 360 is necessary because of the Math.round (eg. 359.5 will become 360) */}
+        Heading: { Math.round(headingFromAssumedNorthStar) % 360 }° from North
+      </div>
+    </div>
+  );
+};
+
+export const Snapshot: React.FC<IProps> = ({ buttonLabel, disabled, snapshot, onTakeSnapshot }) => {
   return (
     <div className={css.snapshot}>
-      <Button className={css.snapshotButton}>{buttonLabel}</Button>
+      {
+        !snapshot &&
+        <Button className={css.snapshotButton} onClick={onTakeSnapshot} disabled={disabled}>{buttonLabel}</Button>
+      }
+      {
+        snapshot &&
+        <SnapshotData snapshot={snapshot} />
+      }
     </div>
   );
 };

--- a/star-navigation/src/config.ts
+++ b/star-navigation/src/config.ts
@@ -3,9 +3,6 @@ import ConstellationsPng from "./assets/Constellations_illustrationsMapping_2307
 
 // Simulation configuration that can be overwritten using URL parameters.
 export interface IConfig {
-  // `undefined` (based on browser local setting) or ISO 639-1 Language Code
-  // for the given language (i.e., `es` for Spanish or `de` for German).
-  lang: string | undefined;
   // Horizon view camera FOV.
   horizonFov: number;
   // Horizon view camera angle.
@@ -20,6 +17,8 @@ export interface IConfig {
   minAbsStarMagnitude: number;
 
   //--- New Alaskan Simulation Star Navigation params: ---
+  observerLat: number;
+  observerLong: number;
   constellations: string;
   constellationsOpacity: number;
   // Whether to show the route map on the right side of the star map.
@@ -33,7 +32,9 @@ export interface IConfig {
 }
 
 const defaultConfig: IConfig = {
-  lang: undefined,
+  // Observer location is at Hooper Bay, Alaska.
+  observerLat: 61.523997904,
+  observerLong: -166.090999636,
   horizonFov: 85,
   cameraVerticalAngle: 34, // deg
   starSizeMult: 0.5,

--- a/star-navigation/src/types.ts
+++ b/star-navigation/src/types.ts
@@ -19,21 +19,21 @@ export enum Constellation {
   Aquila = "CONSTELLATION.AQUILA",
 }
 
-export enum Month {
+export const Month: Record<number, string> = {
   // Translation keys should match the values.
-  January = "MONTH.JANUARY",
-  February = "MONTH.FEBRUARY",
-  March = "MONTH.MARCH",
-  April = "MONTH.APRIL",
-  May = "MONTH.MAY",
-  June = "MONTH.JUNE",
-  July = "MONTH.JULY",
-  August = "MONTH.AUGUST",
-  September = "MONTH.SEPTEMBER",
-  October = "MONTH.OCTOBER",
-  November = "MONTH.NOVEMBER",
-  December = "MONTH.DECEMBER",
-}
+  1: "MONTH.JANUARY",
+  2: "MONTH.FEBRUARY",
+  3: "MONTH.MARCH",
+  4: "MONTH.APRIL",
+  5: "MONTH.MAY",
+  6: "MONTH.JUNE",
+  7: "MONTH.JULY",
+  8: "MONTH.AUGUST",
+  9: "MONTH.SEPTEMBER",
+  10: "MONTH.OCTOBER",
+  11: "MONTH.NOVEMBER",
+  12: "MONTH.DECEMBER",
+};
 
 export interface IStarData {
   Hip: number; // Hipparcos catalog number
@@ -60,6 +60,17 @@ export interface IAngleMarker {
   createdAtEpoch: number;
 }
 
+export const SNAPSHOT_REQUESTED = "snapshot-requested";
+
+export interface ISnapshot {
+  month: number;
+  day: number;
+  timeOfDay: number; // [0, 24]
+  assumedNorthStarHip: number;
+  realHeadingFromNorth: number;
+  starViewImageSnapshot: string;
+}
+
 export interface IModelInputState {
   month: number;
   day: number;
@@ -69,6 +80,11 @@ export interface IModelInputState {
   realHeadingFromNorth: number; // degree
   assumedNorthStarHip: number | null;
   angleMarker: IAngleMarker | null;
+  pointADepartureSnapshot: ISnapshot | null;
+  pointBArrivalSnapshot: ISnapshot | null;
+  pointBDepartureSnapshot: ISnapshot | null;
+  pointCArrivalSnapshot: ISnapshot | null;
+  journeyLeg: "AtoB" | "BtoC";
   // interactions
   compassInteractionActive: boolean;
   angleMarkerInteractionActive: boolean;

--- a/star-navigation/src/utils/sim-utils.ts
+++ b/star-navigation/src/utils/sim-utils.ts
@@ -53,8 +53,8 @@ export const getTimezone = (month: number, day: number) => {
   return PST;
 };
 
-export const getDateTimeString = (month: number, day: number, hour: number) =>
-  `${SIMULATION_YEAR}-${formatTimeNumber(month)}-${formatTimeNumber(day)}T${fractionalHourToTimeString(hour)}${getTimezone(month, day)}`;
+export const getDateTimeString = ({ month, day, timeOfDay } : { month: number, day: number, timeOfDay: number}) =>
+  `${SIMULATION_YEAR}-${formatTimeNumber(month)}-${formatTimeNumber(day)}T${fractionalHourToTimeString(timeOfDay)}${getTimezone(month, day)}`;
 
 
 export const getCelestialSphereRotation = (options: { epochTime: number, lat: number, long: number }): [number, number, number] => {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185463715

This PR adds more functionality to the star nav right panel.

One of the more tricky things is taking snapshots of the 3D sky view. It happens in star-view.tsx via a new component called `TakeSnapshot`. Kinda similar to how the `SutterbugSupport` works. Another relate thing is that I've used a slightly weird pattern of using app state to request snapshots instead of using Forwarding Refs and imperative component API. So, when the right panel adds a snapshot, it sets the snapshot image to a special value `SNAPSHOT_REQUESTED`. Then, when the simulation view and star view notice this value, they request a snapshot and update the state to a final one.

I've also made sure that 4 snapshots will fit the Firestore document (1MB max) by requesting a pretty low-quality JPEG snapshot (35-50kB) instead of PNG (500kB and more).