### PR TITLE
fix: fix minimap dragging on ipad / touch devices [PT-185697751]

### DIFF
--- a/common/src/components/simulation-frame/simulation-frame.tsx
+++ b/common/src/components/simulation-frame/simulation-frame.tsx
@@ -11,8 +11,11 @@ import { Credits } from "./credits";
 
 import css from "./simulation-frame.scss";
 
+// Credits content is not provided yet so this is set to false.
+const SHOW_CREDITS = false;
+
 interface IProps {
-  directions: string | ReactNode;
+  directions?: string | ReactNode;
   className?: string;
   titleImage?: string;
   children?: React.ReactNode;
@@ -44,7 +47,10 @@ export const SimulationFrame: React.FC<IProps> = ({ directions, className, title
       <div id={simulationFrameHeaderId} className={css.header}>
         <div className={clsx(css.buttons, css.left)}>
           <img className={css.logo} src={Logo}/>
-          <button className={clsx({ [css.active]: showCredits })} onClick={toggleCredits}>{ tStringOnly("CREDITS.HEADER") }</button>
+          {
+            SHOW_CREDITS &&
+            <button className={clsx({ [css.active]: showCredits })} onClick={toggleCredits}>{ tStringOnly("CREDITS.HEADER") }</button>
+          }
         </div>
         <div className={css.titleContainer}><img className={css.title} src={titleImage}/></div>
         <div className={clsx(css.buttons, css.right)}>
@@ -53,9 +59,12 @@ export const SimulationFrame: React.FC<IProps> = ({ directions, className, title
             label={"Read Aloud in Yugtun"}
             onChange={handleSetReadAloud}
           />
-          <button className={clsx({ [css.active]: showDirections })} onClick={toggleDirections}>
-            <DirectionsButton />
-          </button>
+          {
+            directions &&
+            <button className={clsx({ [css.active]: showDirections })} onClick={toggleDirections}>
+              <DirectionsButton />
+            </button>
+          }
         </div>
       </div>
       <div className={css.content}>
@@ -63,7 +72,8 @@ export const SimulationFrame: React.FC<IProps> = ({ directions, className, title
         {
           showCredits && <Credits onClose={toggleCredits} />
         }
-        {showDirections &&
+        {
+          directions && showDirections &&
           <Dialog
             title={t("INSTRUCTIONS.HEADER")}
             onClose={toggleDirections} showCloseButton={true}

--- a/star-navigation/src/components/app.tsx
+++ b/star-navigation/src/components/app.tsx
@@ -3,7 +3,6 @@ import { useInteractiveState } from "@concord-consortium/lara-interactive-api";
 import { SimulationFrame, TranslationContext } from "common";
 import { SimulationView } from "./simulation/simulation-view";
 import { IInteractiveState, IModelInputState } from "../types";
-import { skyModelerDirections } from "./sky-modeler-directions";
 import { pointA, pointC } from "./right-container/route-map";
 import { config } from "../config";
 import { getDateTimeString } from "../utils/sim-utils";
@@ -80,7 +79,8 @@ export const App: React.FC<IProps> = ({ readOnly }) => {
       <SimulationFrame
         className={css.simulationFrame}
         titleImage={HeaderTitle}
-        directions={skyModelerDirections()} // ReactNode is also allowed if more complex content is needed.
+        // No directions were provided so for now the help button and dialog are disabled
+        // directions={skyModelerDirections()} // ReactNode is also allowed if more complex content is needed.
       >
         <div className={css.content}>
           <div className={css.leftColumn}>

--- a/star-navigation/src/components/right-container/route-map.scss
+++ b/star-navigation/src/components/right-container/route-map.scss
@@ -50,13 +50,23 @@
   }
 
   .draggableIcon {
+    $draggableWidth: 70px;
+    $iconHeight: 32px;
+    width: $draggableWidth;
+    height: $draggableWidth;
+    margin-left: -0.5 * $draggableWidth;
+    margin-top: -0.5 * $draggableWidth - 0.5 * $iconHeight;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
     position: absolute;
     top: 0;
     left: 0;
 
     svg {
       width: 30px;
-      height: 32px;
+      height: $iconHeight;
       stroke: $midnight-blue;
       stroke-width: 30;
       fill: $lightBlue;

--- a/star-navigation/src/components/right-container/route-map.tsx
+++ b/star-navigation/src/components/right-container/route-map.tsx
@@ -13,7 +13,7 @@ const mapHeight = 150;
 
 // The real distance between point A and point C is 17 miles.
 const pixelToMileRatio = 17 / (pointC.x - pointA.x);
-const travelSpeed = 20; // miles per hour, snowmobile speed
+const travelSpeed = 10; // miles per hour, snowmobile speed
 
 // Don't let users drag to the very edges of the map.
 const xDraggingMargin = 10;

--- a/star-navigation/src/components/right-container/route-map.tsx
+++ b/star-navigation/src/components/right-container/route-map.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState, useRef, useCallback } from "react";
 import { roundToNearest5 } from "../../utils/sim-utils";
 import LocationSymbol from "../../assets/location-symbol.svg";
 
@@ -74,6 +74,32 @@ export const RouteMap: React.FC<IProps> = ({ pointB, onPointBChange, showUserTri
     realPointC = { x: realPointB.x + realBtoCOffset.x, y: realPointB.y - realBtoCOffset.y };
   }
 
+  const handlePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const { x, y } = getRelativeCoords(e);
+    draggingOffset.current = { x: x - pointB.x, y: y - pointB.y };
+    setIsDragging(true);
+  }, [pointB.x, pointB.y]);
+
+  const handlePointerUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  const cancelNativeScroll = useCallback((e: React.TouchEvent | TouchEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+  }, []);
+
+  // Prevent scrolling when user touches the map on iPad. It's likely that they want to drag the point instead.
+  // Native scrolling is distracting and makes it harder to drag the point. It's necessary to use native events
+  // because calling preventDefault() on React's synthetic events won't prevent scrolling.
+  useEffect(() => {
+    const container = draggingContainerRef.current;
+    container?.addEventListener("touchmove", cancelNativeScroll);
+    return () => {
+      container?.removeEventListener("touchmove", cancelNativeScroll);
+    };
+  }, [cancelNativeScroll]);
+
   useEffect(() => {
     const handlePointerMove = (e: PointerEvent) => {
       let { x, y } = getRelativeCoords(e);
@@ -101,9 +127,6 @@ export const RouteMap: React.FC<IProps> = ({ pointB, onPointBChange, showUserTri
       }
     };
 
-    const handlePointerUp = () => {
-      setIsDragging(false);
-    };
     if (isDragging) {
       window.addEventListener("pointerup", handlePointerUp);
       window.addEventListener("pointermove", handlePointerMove);
@@ -112,20 +135,14 @@ export const RouteMap: React.FC<IProps> = ({ pointB, onPointBChange, showUserTri
       window.removeEventListener("pointerup", handlePointerUp);
       window.removeEventListener("pointermove", handlePointerMove);
     };
-  }, [isDragging, onPointBChange]);
+  }, [handlePointerUp, isDragging, onPointBChange]);
 
   const getRelativeCoords = (e: PointerEvent | React.PointerEvent) => {
-    const { x: containerX, y: containerY } = draggingContainerRef.current?.getBoundingClientRect() || { x: 0, y: 0};
+    const { x: containerX, y: containerY } = draggingContainerRef.current?.getBoundingClientRect() || { x: 0, y: 0 };
     const x = e.clientX - containerX;
     const y = e.clientY - containerY;
     return { x, y };
   };
-
-  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-    const { x, y } = getRelativeCoords(e);
-    draggingOffset.current = { x: x - pointB.x, y: y - pointB.y };
-    setIsDragging(true);
-   };
 
   const getBACAngle = (xb: number, yb: number) => {
     return radToDeg(Math.atan2(Math.abs(yb - pointA.y), xb - pointA.x));
@@ -211,10 +228,6 @@ export const RouteMap: React.FC<IProps> = ({ pointB, onPointBChange, showUserTri
     );
   };
 
-  /* offset location icon by half its width and height so the bottom of it is aligned with point b*/
-  const locIconXOffset = pointB.x - 15;
-  const locIconYOffset = pointB.y - 32;
-
   return (
     <div className={css.mapRouteContainer} ref={draggingContainerRef}>
       <div className={css.svgContainer}>
@@ -238,7 +251,7 @@ export const RouteMap: React.FC<IProps> = ({ pointB, onPointBChange, showUserTri
         <div
           className={css.draggableIcon}
           style={{
-            transform: `translateX(${locIconXOffset}px) translateY(${locIconYOffset}px)`,
+            transform: `translateX(${pointB.x}px) translateY(${pointB.y}px)`,
             cursor: isDragging ? "grabbing" : "grab"
           }}
           onPointerDown={handlePointerDown}


### PR DESCRIPTION
This PR fixes issues with dragging on iPad observed by Saravanan:
https://www.pivotaltracker.com/story/show/185697751/comments/237827704

Also, it makes the draggable area bigger so it's easier to drag it on touch devices (I had a hard time dragging it on my phone when the size was set to 30x32px).

And again, I'm including a few tiny, random changes, not to open X new PRs for all of them.